### PR TITLE
fixed : if no face found raise a Exception

### DIFF
--- a/models/faceFeature.py
+++ b/models/faceFeature.py
@@ -54,12 +54,17 @@ class FaceFeature:
     def get(self, image: np.ndarray):
         gray_scale = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         rects = self.detector(gray_scale, 1)
-        rect = rects[0]
-        # determine the facial landmarks for the face region, then
-        # convert the landmark (x, y)-coordinates to a NumPy array
-        shape = self.predictor(gray_scale, rect)
-        shape = shape_to_numpy_array(shape)
+        if rects:
+            # returns first face in list
+            rect = rects[0]
+            # determine the facial landmarks for the face region, then
+            # convert the landmark (x, y)-coordinates to a NumPy array
+            shape = self.predictor(gray_scale, rect)
+            shape = shape_to_numpy_array(shape)
 
-        left, right, mouth = get_feature(shape)
-        return left, right, mouth
+            left, right, mouth = get_feature(shape)
+            return left, right, mouth
+        else:
+            # if not a single face is present in image
+            raise Exception("face was not in an image")
 


### PR DESCRIPTION
# faceFeat 모델에서 얼굴이 없으면 raise를 할꺼예요!

```
/opt/homebrew/Caskroom/miniforge/base/envs/hair/bin/python /Users/jinwoo/HAiR/test.py
Traceback (most recent call last):
  File "/Users/jinwoo/HAiR/test.py", line 8, in <module>
    AL = Aligner(BB)
  File "/Users/jinwoo/HAiR/src/components/Aligner/Aligner.py", line 21, in __init__
    self.bounding_box.get_bounding_box()
  File "/Users/jinwoo/HAiR/src/components/BoundingBox/BoundingBox.py", line 33, in get_bounding_box
    left_eye, right_eye, mouth = self.faceFeat.get(self.original_image)
  File "/Users/jinwoo/HAiR/models/faceFeature.py", line 69, in get
    raise Exception("face was not in an image")
Exception: face was not in an image

Process finished with exit code 1
```
**Exception: face was not in an image**
중간 transformer(#9)에서 try catch문을 사용해야할것 같습니다.