### PR TITLE
Impl #40

### DIFF
--- a/src/components/Aligner/AlignerWing.py
+++ b/src/components/Aligner/AlignerWing.py
@@ -7,6 +7,7 @@ from torchvision.utils import make_grid
 from torch import uint8
 import os
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 class AlignerWing:
     """
     origin_patch와 얼굴중심, margin, 회전각 theta를 받아
@@ -17,36 +18,44 @@ class AlignerWing:
     aling_backward시
     헤어스타일이 변경된 align_patch를 받으면 원래 origin_patch에 덮어쓴 origin_patch를 반환
     """
+    FaceAligner = FaceAligner(os.path.join(BASE_DIR, '..\\..\\..\\models\\checkpoints\\wing\\wing.ckpt'),
+                                   os.path.join(BASE_DIR, '..\\..\\..\\models\\checkpoints\\wing\\celeba_lm_mean.npz'),
+                                   512)
 
-    def __init__(self, bounding_box: BoundingBox):
+    def __init__(self, bounding_box: BoundingBox = None):
+        if bounding_box is not None:
+            self.set_bounding_box(bounding_box)
+
+        self.origin_landmarks = None
+
+    def set_bounding_box(self, bounding_box: BoundingBox):
         self.bounding_box = bounding_box
         self.bounding_box.get_bounding_box()
         self.origin_patch = self.bounding_box.get_origin_patch()
-        self.rotated_patch = None
-        self.aligned_patch = None
 
-        BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-        self.FaceAligner = FaceAligner(os.path.join(BASE_DIR, '..\\..\\..\\models\\checkpoints\\wing\\wing.ckpt'),
-                                os.path.join(BASE_DIR, '..\\..\\..\\models\\checkpoints\\wing\\celeba_lm_mean.npz'),
-                                512)
+    def check_initialized(self):
+        if self.bounding_box is None:
+            raise Exception("bounding_box is None")
 
     def align_forward(self) -> np.ndarray:
         '''
         origin_patch로 부터 aligned_patch를 반환합니다.
         return : margin * margin 크기의 aligned_patch
         '''
+        self.check_initialized()
+
         def denormalize(x):
             out = (x + 1) / 2
             return out.clamp_(0, 1)
 
-        result = align_face(512, self.origin_patch, self.FaceAligner)
+        result, origin_landmarks = align_face(512, self.origin_patch, AlignerWing.FaceAligner)
+        self.origin_landmarks = origin_landmarks
         result = denormalize(result)
         # result : tensor
 
         grid = make_grid(result)
         result = grid.mul(255).add_(0.5).clamp_(0, 255).permute(1, 2, 0).to('cpu', uint8).numpy()
         # result : ndarray
-        self.aligned_patch = result
         return result
 
     def align_backward(self, style_changed_aligned_patch: np.ndarray) -> np.ndarray:
@@ -55,11 +64,16 @@ class AlignerWing:
         param style_changed_aligned_patch : 기존 aligned_patch에서 스타일만 변경된 이미지
         return : 기존 origin_patch에서 스타일만 변경된 이미지
         '''
+        self.check_initialized()
+
         def denormalize(x):
             out = (x + 1) / 2
             return out.clamp_(0, 1)
 
-        result = align_face_restore(512, style_changed_aligned_patch, self.FaceAligner)
+        if self.origin_landmarks is None:
+            raise Exception("origin_landmakrs가 없습니다. align_forward를 먼저 실행해 주세요.")
+
+        result = align_face_restore(512, style_changed_aligned_patch, self.origin_landmarks, AlignerWing.FaceAligner)
         result = denormalize(result)
         # result : tensor
 

--- a/src/components/BoundingBox/BoundingBox.py
+++ b/src/components/BoundingBox/BoundingBox.py
@@ -9,7 +9,7 @@ class BoundingBox:
     origin_image로 부터 눈, 코, 입 좌표를 추출하고
     얼굴 중심을 구한 뒤 회전각을 구하고 Margin을 구해서 origin_image에서 bounding box를 구합니다.
     """
-
+    faceFeat = FaceFeature()
     def __init__(self, original_image: np.ndarray):
         '''
         param original_image : 1920 * 1080 크기의 카메라로 들어온 입력 이미지
@@ -19,7 +19,6 @@ class BoundingBox:
         self.rotation = None
         self.theta = None
         self.face_center = None
-        self.faceFeat = FaceFeature()
         self.image_coords = []
 
     def get_bounding_box(self):
@@ -30,7 +29,7 @@ class BoundingBox:
         # BoundingBox = 얼굴 중심 ~ Margin*(sin(회전각) + cos(회전각))
 
         # 왼쪽눈, 오른쪽눈, 입의 위치 파악
-        left_eye, right_eye, mouth = self.faceFeat.get(self.original_image)
+        left_eye, right_eye, mouth = BoundingBox.faceFeat.get(self.original_image)
 
         # 얼굴의 중심
         self.face_center = (sum((left_eye[0], right_eye[0], mouth[0])) // 3,

--- a/src/components/MaskOrientGenerator/MaskOrientGenerator.py
+++ b/src/components/MaskOrientGenerator/MaskOrientGenerator.py
@@ -5,9 +5,8 @@ from src.components.MaskOrientGenerator.faceSegmentation import FaceSegmentation
 
 
 class MaskOrientGenerator:
-    def __init__(self):
-        self.faceSegmentation = FaceSegmentation()
-        self.orient = Orient()
+    faceSegmentation = FaceSegmentation()
+    orient = Orient()
 
     def generate(self, aligned_scaled_patch: np.ndarray) -> tuple:
         '''
@@ -26,7 +25,7 @@ class MaskOrientGenerator:
         param image : 원본 이미지
         return : image의 마스크
         '''
-        return self.faceSegmentation.image_to_mask(image, 256, 512)
+        return MaskOrientGenerator.faceSegmentation.image_to_mask(image, 256, 512)
 
     def generate_orient(self, image: np.ndarray, mask: np.ndarray) -> np.ndarray:
         '''
@@ -35,4 +34,4 @@ class MaskOrientGenerator:
               mask  : 원본 이미지의 마스크
         return : image의 orient dense
         '''
-        return self.orient.makeOrient(image, mask)
+        return MaskOrientGenerator.orient.makeOrient(image, mask)

--- a/src/transformers/ComponentFactory.py
+++ b/src/transformers/ComponentFactory.py
@@ -1,0 +1,50 @@
+from src.components.Aligner.AlignerWing import AlignerWing
+from src.components.BoundingBox.BoundingBox import BoundingBox
+from models.baldgan import BaldGAN, model_path
+from src.components.Scaler.Scaler import Scaler
+
+class Balder:
+    def __init__(self, baldGAN):
+        self.baldGAN = baldGAN
+        self.scaler = None
+
+    def run(self, aligned_face_patch_src):
+        self.scaler = Scaler(aligned_face_patch_src, target_size=256)
+        scaled_256_src = self.scaler.scale_forward()
+        return Scaler(self.baldGAN.go_bald(scaled_256_src)).scale_forward()
+
+class NoBalder:
+    def __init__(self):
+        self.scaler = None
+
+    def run(self, aligned_face_patch_src):
+        self.scaler = Scaler(aligned_face_patch_src)
+        return self.scaler.scale_forward()
+
+def BoundingBoxFactory(img):
+    return BoundingBox(img)
+
+def AlignerWingFactory(boundingBox):
+    return AlignerWing(boundingBox)
+
+def AlignerFactory(boundingBox):
+    from src.components.Aligner.Aligner import Aligner
+    return Aligner(boundingBox)
+
+def BalderFactory():
+    return Balder(baldGans['model_G_5_170'])
+
+def Balder_5_170_Factory():
+    return Balder(baldGans['model_G_5_170_retrained'])
+
+def Balder_10_170_Factory():
+    return Balder(baldGans['model_G_10_340'])
+
+check_points = ['model_G_5_170', 'model_G_5_170_retrained', 'model_G_10_340']
+
+def b(ckpt):
+    bald = BaldGAN()
+    bald.model.load_weights(model_path + ckpt + '.hdf5')
+    return bald
+
+baldGans = {ckpt: b(ckpt) for ckpt in check_points}

--- a/src/transformers/Test.py
+++ b/src/transformers/Test.py
@@ -79,8 +79,8 @@ def test(src_files=[], appearance_ref_files=[], ss_ref_files=[], tVariant=True, 
                     if not os.path.isdir(result_dir):
                         os.mkdir(result_dir)
                     cv2.imwrite(file, result)
-                except:
-                    print('error')
+                except Exception as e:
+                    print(e)
 
     print('total time :', time.time() - start)
 

--- a/src/transformers/Test.py
+++ b/src/transformers/Test.py
@@ -30,6 +30,7 @@ def test(src_files=[], appearance_ref_files=[], ss_ref_files=[], tVariant=True, 
 
     # 조합별 Transformer
     transformers = {'wing_based_eye_distance_based_model_G_5_170': getTransformer()}
+    transformers['wing_based_eye_distance_based_model_G_5_170'].pass_through = False
 
     if tVariant:
         for a_key, bb_key, bd_key in product(alignerFactories.keys(),

--- a/src/transformers/Test.py
+++ b/src/transformers/Test.py
@@ -1,0 +1,91 @@
+import cv2
+from src.transformers.Transformer import Transformer, getTransformer
+from src.transformers.ComponentFactory import *
+
+alignerFactories = {
+    'wing_based': AlignerWingFactory, # default
+    # 'cv_based': AlignerFactory,
+}
+
+boundingBoxFactories = {
+    'eye_distance_based': BoundingBoxFactory # default
+}
+
+balderFactories = {
+    'model_G_5_170': BalderFactory, # default
+    'model_G_5_170_retrained': Balder_5_170_Factory,
+    'model_G_10_340': Balder_10_170_Factory,
+}
+
+def test(src_files=[], appearance_ref_files=[], ss_ref_files=[], tVariant=True, rVariant=True):
+    # tVariant : True시 가능한 모든 Transformer 조합을 대상으로 테스트를 수행합니다.
+    # rVariant : True시 가능한 모든 레퍼런스 조합을 대상으로 테스트를 수행 합니다.
+
+    from itertools import product
+    import os
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    def getImage(filename):
+        return cv2.imread('{}/../../data/{}.jpg'.format(BASE_DIR, filename))
+
+    # 조합별 Transformer
+    transformers = {'wing_based_eye_distance_based_model_G_5_170': getTransformer()}
+
+    if tVariant:
+        for a_key, bb_key, bd_key in product(alignerFactories.keys(),
+                                             boundingBoxFactories.keys(),
+                                             balderFactories.keys()):
+            transformers['{}--{}--{}'.format(a_key, bb_key, bd_key)] = Transformer(boundingBoxFactories[bb_key],
+                                                                                 alignerFactories[a_key],
+                                                                                 balderFactories[bd_key])
+
+    # 조합별 Reference
+    appearance_refs = {file : getImage(file) for file in appearance_ref_files}
+    appearance_refs['none'] = None
+
+    shape_and_structure_refs = {file : getImage(file) for file in ss_ref_files}
+    shape_and_structure_refs['none'] = None
+
+    refs = {'none_{}_{}'.format(s_key, s_key) : [None, getImage(s_key)] for s_key in list(shape_and_structure_refs.keys())[:1]}
+
+    if rVariant:
+        for a_key, s_key, in product(appearance_refs.keys(), shape_and_structure_refs.keys()):
+            refs['{}_{}_{}'.format(a_key, s_key, s_key)] = [appearance_refs[a_key],
+                                                            shape_and_structure_refs[s_key]]
+
+    if not os.path.isdir('results'):
+        os.mkdir('results')
+
+    import time
+    start = time.time()
+    for src_file in src_files:
+        src = getImage(src_file)
+
+        for r_key in refs.keys():
+            appearance_ref, shape_and_structure_ref = refs[r_key]
+
+            for t_key, transformer in transformers.items():
+                result_dir = 'results/{}'.format(t_key)
+                file = '{}/{}_{}.jpg'.format(result_dir, src_file, r_key)
+                print(file, 'started')
+
+                transformer.set_appearance_ref(appearance_ref)
+                transformer.set_shape_ref(shape_and_structure_ref)
+                transformer.set_structure_ref(shape_and_structure_ref)
+
+                try:
+                    result = transformer.transform(src)
+
+                    if not os.path.isdir(result_dir):
+                        os.mkdir(result_dir)
+                    cv2.imwrite(file, result)
+                except:
+                    print('error')
+
+    print('total time :', time.time() - start)
+
+test(src_files=['1'],
+     appearance_ref_files=['lee'],
+     ss_ref_files=['kim'],
+     tVariant=False,
+     rVariant=False)

--- a/src/transformers/Transformer.py
+++ b/src/transformers/Transformer.py
@@ -1,13 +1,178 @@
-from abc import *
 import numpy as np
 
-class Transformer(metaclass=ABCMeta):
-    @abstractmethod
-    def set_reference(self):
-        pass
-    
-    @abstractmethod
+import cv2
+
+from models.baldgan import BaldGAN
+from src.components.Aligner.AlignerWing import AlignerWing
+from src.components.BoundingBox.BoundingBox import BoundingBox
+from src.components.MaskOrientGenerator.MaskOrientGenerator import MaskOrientGenerator
+from src.components.Scaler.Scaler import Scaler
+from src.util.sender import Sender
+
+class Transformer:
+    def __init__(self):
+
+        self.appearance_ref = None
+        self.shape_ref = None
+        self.structure_ref = None
+
+        self.sender = Sender()
+        self.MOGenerator = MaskOrientGenerator()
+
+    def set_appearance_ref(self, ref: np.ndarray):
+        self.appearance_ref = ref
+
+    def set_shape_ref(self, ref: np.ndarray):
+        self.shape_ref = ref
+
+    def set_structure_ref(self, ref: np.ndarray):
+        self.structure_ref = ref
+
     def transform(self, original_image: np.ndarray) -> np.ndarray:
         # original_image : 1920 x 1080
         # return : 1920 x 1080
-        pass
+
+        boundingBox = BoundingBox(original_image)
+        aligner = AlignerWing(boundingBox)
+
+        balder = Balder(BaldGAN())
+        src = self._src_preprocess(aligner, balder)
+
+        appearance_ref, shape_ref, structure_ref = None, None, None
+        if self.appearance_ref is not None:
+            appearance_ref = self._ref_preprocess(AlignerWing(BoundingBox(self.appearance_ref)))
+
+        if self.shape_ref is not None:
+            shape_ref = self._ref_preprocess(AlignerWing(BoundingBox(self.shape_ref)))
+
+        if self.structure_ref is not None:
+            structure_ref = self._ref_preprocess(AlignerWing(BoundingBox(self.structure_ref)))
+
+        # Appearance
+        appearance_mask = src['mask'] if appearance_ref is None else appearance_ref['mask']
+        appearance_img = src['img_origin'] if appearance_ref is None else appearance_ref['img']
+
+        # Shape
+        shape_mask = src['mask'] if shape_ref is None else shape_ref['mask']
+
+        # Structure
+        orient = src['orient'] if structure_ref is None else structure_ref['orient']
+
+        # App : appearance_ref
+        # Shape : shape_ref
+        # Structure : structure_ref
+        # None인 항목은 src의 속성을 유지하도록 변환
+        datas = {
+            'label_ref': appearance_mask,  # appearance
+            'label_tag': shape_mask, # shape
+
+            'orient_mask': shape_mask,  # structure ref mask
+            'orient_tag': orient,  # src orient ???????
+            'orient_ref': orient,  # structure ref orient
+
+            'image_ref': appearance_img,  # appearance
+            'image_tag': src['img_bald'],  # src
+        }
+        generated: np.ndarray = self.sender.send_and_recv(datas)
+
+        generated = balder.scaler.scale_backward(generated)
+        generated = aligner.align_backward(generated)
+        return boundingBox.set_origin_patch(generated)
+
+    def _ref_preprocess(self, aligner):
+        scaled_ref = Scaler((aligner.align_forward())).scale_forward()
+        mask_ref, orient_ref = self.MOGenerator.generate(scaled_ref)
+        ret = {
+            'img': scaled_ref,
+            'mask': mask_ref,
+            'orient': orient_ref
+        }
+        return ret
+
+    def _src_preprocess(self, aligner, bald):
+        aligned_face_patch_src = aligner.align_forward()
+
+        # bald
+        balded_src = bald.run(aligned_face_patch_src)
+
+        src_origin = Scaler(aligned_face_patch_src).scale_forward()
+        mask_src, orient_src = self.MOGenerator.generate(src_origin)
+
+        ret = {
+            'img_origin': src_origin,
+            'img_bald': balded_src,
+            'mask': mask_src,
+            'orient': orient_src
+        }
+        return ret
+
+class Balder:
+    def __init__(self, baldGAN):
+        self.baldGAN = baldGAN
+        self.scaler = None
+
+    def run(self, aligned_face_patch_src):
+        self.scaler = Scaler(aligned_face_patch_src, target_size=256)
+        scaled_256_src = self.scaler.scale_forward()
+        self.scaler = Scaler(self.baldGAN.go_bald(scaled_256_src))
+        return self.scaler.scale_forward()
+
+class NoBalder:
+    def __init__(self):
+        self.scaler = None
+
+    def run(self, aligned_face_patch_src):
+        self.scaler = Scaler(aligned_face_patch_src)
+        return self.scaler.scale_forward()
+
+def getTransformer() -> Transformer:
+    return Transformer()
+
+def test():
+    import os
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    transformer = getTransformer()
+
+    appearance_refs = {
+        'none' : None,
+        'lee' : cv2.imread('{}/../../data/{}.jpg'.format(BASE_DIR, 'lee'))
+    }
+
+    structure_refs = {
+        'none' : None,
+        '10' : cv2.imread('{}/../../data/{}.jpg'.format(BASE_DIR, '10')),
+        'kim': cv2.imread('{}/../../data/{}.jpg'.format(BASE_DIR, 'kim'))
+    }
+
+    shape_refs = {
+        'none' : None,
+        '10': cv2.imread('{}/../../data/{}.jpg'.format(BASE_DIR, '10')),
+        'kim' : cv2.imread('{}/../../data/{}.jpg'.format(BASE_DIR, 'kim'))
+    }
+
+    for img_idx in [2]:
+        src = cv2.imread('{}/../../data/{}.jpg'.format(BASE_DIR, img_idx))
+        for a_key in appearance_refs.keys():
+            appearance_ref = appearance_refs[a_key]
+
+            for st_key in structure_refs.keys():
+                structure_ref = structure_refs[st_key]
+
+                for sh_key in shape_refs.keys():
+                    shape_ref = shape_refs[sh_key]
+
+                    file = 'results/{}_{}_{}_{}.jpg'.format(img_idx, a_key, st_key, sh_key)
+                    print(file, 'started')
+
+                    transformer.set_appearance_ref(appearance_ref)
+                    transformer.set_shape_ref(shape_ref)
+                    transformer.set_structure_ref(structure_ref)
+
+                    try:
+                        result = transformer.transform(src)
+                        cv2.imwrite(file, result)
+                    except:
+                        print('error')
+
+# test()

--- a/src/transformers/Transformer.py
+++ b/src/transformers/Transformer.py
@@ -6,8 +6,9 @@ from src.util.sender import Sender
 
 class Transformer:
     ref_cache = {}
-    def __init__(self, boundingBoxFactory, alignerFactory, balderFactory, caching=True):
+    def __init__(self, boundingBoxFactory, alignerFactory, balderFactory, caching=True, pass_through=False):
         self.caching = caching
+        self.pass_through = pass_through
 
         self.boundingBoxFactory = boundingBoxFactory
         self.alignerFactory = alignerFactory
@@ -32,6 +33,10 @@ class Transformer:
     def transform(self, original_image: np.ndarray) -> np.ndarray:
         # original_image : 1920 x 1080
         # return : 1920 x 1080
+
+        if self.pass_through:
+            if self.appearance_ref is None and self.shape_ref is None and self.structure_ref is None:
+                return original_image
 
         boundingBox = self.boundingBoxFactory(original_image)
 
@@ -130,4 +135,5 @@ from src.transformers.ComponentFactory import *
 def getTransformer() -> Transformer:
     return Transformer(boundingBoxFactory=BoundingBoxFactory,
                        alignerFactory=AlignerWingFactory,
-                       balderFactory=BalderFactory)
+                       balderFactory=BalderFactory,
+                       pass_through=True)

--- a/src/transformers/Transformer.py
+++ b/src/transformers/Transformer.py
@@ -34,7 +34,12 @@ class Transformer:
         # return : 1920 x 1080
 
         boundingBox = self.boundingBoxFactory(original_image)
-        aligner = self.alignerFactory(boundingBox)
+
+        try:
+            aligner = self.alignerFactory(boundingBox)
+        except Exception as e:
+            print(e)
+            return original_image
 
         balder = self.balderFactory()
 


### PR DESCRIPTION
### 변경 사항

- ### 구조 변경점

  - AppearanceTransformer, ShapeStructureTransformer 등 기능별 클래스가 아닌 모든 기능을 포함하는 단일 Transformer 객체로 변경
  - 여러가지의 컴포넌트 조합별 Transformer를 얻을 수 있도록 Transformer의 의존성을 외부에서 주입하도록 변경
  - 여러가지 컴포넌트 조합별, 레퍼런스 조합별로 테스트 할 수 있는 메서드 추가

- ### 성능 튜닝

  - 한번 전처리 된 레퍼런스는 캐싱해서 사용하도록 변경
  - 외부 모델을 사용하는 컴포넌트들의 모델 변수를 static으로 변경하여 최초 한번만 로드하도록 변경
  - 얼굴이 없는 사진이 입력되면 입력을 그대로 반환하도록 변경
  - 레퍼런스가 하나도 선택이 안된 경우 입력을 그대로 반환하도록 변경 (pass_through=True시. 기본 False임 즉. 기본 옵션에서는 레퍼런스 선택이 안되어도 입력을 그대로 반환하지 않음)
  - UI단에서 Transformer객체를 얻기 위해 사용하는 getTransformer() 메서드는 pass_through=True로 생성된 Transformer 객체를 반환함. 즉 레퍼런스 선택이 안되면 입력을 그대로 반환함.

- ### UI 와의 인터페이스

  - Transformer 객체의 생성은 getTransformer() 메서드를 통해서 수행함.

    레퍼런스 전처리 캐싱, 레퍼런스 선택 없을 시 입력 그대로 반환 기본적으로 수행함.

    ```python
    # src/transformers/Transformer.py
    def getTransformer() -> Transformer:
        return Transformer(boundingBoxFactory=BoundingBoxFactory,
                           alignerFactory=AlignerWingFactory,
                           balderFactory=BalderFactory,
                           pass_through=True)
    ```

  - transform 메서드 한번으로 한번의 변환을 수행함. 

    ```python
    # src/transformers/Transformer.py
    def transform(self, original_image: np.ndarray) -> np.ndarray:
    ```

  - 아래 메서드로 레퍼런스를 선택함.

    ```python
    # src/transformers/Transformer.py
    def set_appearance_ref(self, ref: np.ndarray):
    def set_shape_ref(self, ref: np.ndarray):
    def set_structure_ref(self, ref: np.ndarray):
    ```

    

- ### 테스트

  - Transformer를 구성하는 구성요소들을 아래의 dict에서 하나씩 선택해 Transformer를 구성할 수 있음.

    ```python
    alignerFactories = {
        'wing_based': AlignerWingFactory, # default
        # 'cv_based': AlignerFactory,
    }
    
    boundingBoxFactories = {
        'eye_distance_based': BoundingBoxFactory # default
    }
    
    balderFactories = {
        'model_G_5_170': BalderFactory, # default
        'model_G_5_170_retrained': Balder_5_170_Factory,
        'model_G_10_340': Balder_10_170_Factory,
    }
    ```

  - BaldGAN를 체크포인트별로 테스트하고 싶다면 check_points 목록에 확장자를 제외한 파일명을 추가하고, 아래 메서드와 같은 양식으로 추가한 다음. 위 balderFactories에 추가해주면 됨.

    ```python
    # src/transformers/ComponentFactory.py
    def BalderFactory():
        return Balder(baldGans['model_G_5_170'])
    
    def Balder_5_170_Factory():
        return Balder(baldGans['model_G_5_170_retrained'])
    
    def Balder_10_170_Factory():
        return Balder(baldGans['model_G_10_340'])
    
    check_points = ['model_G_5_170', 'model_G_5_170_retrained', 'model_G_10_340']
    
    def b(ckpt):
        bald = BaldGAN()
        bald.model.load_weights(model_path + ckpt + '.hdf5')
        return bald
    
    baldGans = {ckpt: b(ckpt) for ckpt in check_points}
    ```

  - 테스트 메서드의 파라미터 순서대로 입력, app_ref, ss_ref 파일명 목록이고, 
    tVarient를 True로 설정하면 앞선 컴포넌트 목록의 모든 조합으로 컴포넌트를 생성해 테스트를 수행함.
    rVarient를 True로 설정하면 파라미터에 넘겨준 목록의 모든 조합으로 변환 테스트를 수행함. 

    ```python
    test(src_files=['1'],
         appearance_ref_files=['lee'],
         ss_ref_files=['kim'],
         tVariant=False,
         rVariant=False)
    ```

    

  - 입력 파일들의 기본 위치는 /data/

    ```python
    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
    def getImage(filename):
        return cv2.imread('{}/../../data/{}.jpg'.format(BASE_DIR, filename))
    ```

    

  - 출력 파일들의 기본 위치는 /src/transformers/results/
    출력 파일을 생성한 트랜스포머의 조합명으로 폴더를 생성하고 그 하위에 레퍼런스 조합별 결과물이 저장됨.

    ```python
    result_dir = 'results/{}'.format(t_key)
    file = '{}/{}_{}.jpg'.format(result_dir, src_file, r_key)
    ```
![image](https://user-images.githubusercontent.com/23726218/129677173-991227f6-a864-48a0-92d1-8ac54f8d0c5d.png)
